### PR TITLE
feat: add proceeding number and point badges to home feed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+/.claude

--- a/app/(home)/articles-section.tsx
+++ b/app/(home)/articles-section.tsx
@@ -9,14 +9,16 @@ import { useInfiniteScroll } from '@/lib/hooks/use-infinite-scroll'
 
 const ITEMS_PER_PAGE = 10
 
-export default function ArticlesSection({ 
-  posts, 
-  sort, 
-  allCategories, 
-}: { 
+export default function ArticlesSection({
+  posts,
+  sort,
+  allCategories,
+  maxProceedingNumber,
+}: {
   posts: LatestPointsResult[]
   sort: string
   allCategories: string[]
+  maxProceedingNumber: number
 }) {
   const [displayedPosts, hasMore, loadMore] = useInfiniteScroll(posts, ITEMS_PER_PAGE)
   const loadingRef = useRef<HTMLDivElement>(null)
@@ -47,10 +49,12 @@ export default function ArticlesSection({
       <div className="space-y-2 md:space-y-4">
         {displayedPosts.map((post) => (
           <div key={`${post.proceedingNumber}-${post.pointId}`}>
-            <PostCard 
+            <PostCard
               {...post}
               comments={parseInt(post.comments) || 0}
               proceedingNumber={post.proceedingNumber.toString()}
+              officialPoint={post.officialPoint}
+              maxProceedingNumber={maxProceedingNumber}
             />
             <hr className="border-t border-gray-200 mb-4" />
           </div>

--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -2,6 +2,7 @@ import {
   getLatestProceedingPoints,
   getPopularProceedingPoints,
   getAllCategories,
+  getMaxProceedingNumber,
 } from '@/lib/supabase/getProceedings'
 import ArticlesSection from './articles-section'
 import Sidebar from './sidebar'
@@ -33,9 +34,10 @@ export default async function FeedPage({ searchParams }: PageProps) {
   const params = await searchParams
   const sort = typeof params?.sort === 'string' ? params.sort : 'foryou'
 
-  const [posts, allCategories] = await Promise.all([
+  const [posts, allCategories, maxProceedingNumber] = await Promise.all([
     getPosts(sort),
     getAllCategories(),
+    getMaxProceedingNumber(),
   ])
 
   return (
@@ -45,6 +47,7 @@ export default async function FeedPage({ searchParams }: PageProps) {
           posts={posts}
           sort={sort}
           allCategories={allCategories}
+          maxProceedingNumber={maxProceedingNumber}
         />
       </div>
       <div className="hidden lg:block w-80 flex-shrink-0">

--- a/app/(home)/post-card.tsx
+++ b/app/(home)/post-card.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { ImageWithFallback } from '@/components/ui/image-with-fallback'
-import { MessageSquare, Share2, Vote } from 'lucide-react'
+import { MessageSquare, Share2, Vote, Calendar, Hash } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import Link from 'next/link'
@@ -18,6 +18,8 @@ export default function PostCard({
   proceedingNumber,
   date,
   votingNumbers,
+  officialPoint,
+  maxProceedingNumber,
   initialVotes = { upvotes: 0, downvotes: 0 },
 }: {
   category: string
@@ -28,17 +30,31 @@ export default function PostCard({
   proceedingNumber: string
   date: string
   votingNumbers?: any[]
+  officialPoint?: string | null
+  maxProceedingNumber: number
   initialVotes?: { upvotes: number; downvotes: number }
 }) {
   const hasVotes = Boolean(votingNumbers?.length)
   const [isSharing, setIsSharing] = useState(false)
-  
+
   const postUrl = `/proceedings/${proceedingNumber}/${date}/${pointId}`
   const formattedDate = new Date(date).toLocaleDateString('pl-PL', {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
   })
+
+  // Get proceeding label
+  const proceedingNum = parseInt(proceedingNumber)
+  let proceedingLabel = proceedingNumber
+  if (proceedingNum === maxProceedingNumber) {
+    proceedingLabel = `${proceedingNumber} (ostatnie)`
+  } else if (proceedingNum === maxProceedingNumber - 1) {
+    proceedingLabel = `${proceedingNumber} (przedostatnie)`
+  }
+
+  // Clean official point text
+  const cleanOfficialPoint = officialPoint?.replace(/porządku dziennego/gi, '').trim()
 
   const handleShare = async (e: React.MouseEvent) => {
     e.preventDefault()
@@ -80,12 +96,24 @@ export default function PostCard({
       <div className="flex flex-col md:flex-row items-start gap-3 sm:gap-6">
         {/* Text content */}
         <div className="flex-1 min-w-0 order-2 md:order-1">
-          {/* Category and badges */}
-          <div className="flex items-center gap-2 flex-wrap mb-2">
+          {/* Category */}
+          <div className="flex items-center gap-2 mb-2">
             <span className="text-primary text-sm font-medium flex items-center gap-2">
               <span className="w-2 h-2 bg-primary rounded-full" />
               {category}
             </span>
+          </div>
+          {/* Badges */}
+          <div className="flex items-center gap-2 flex-wrap mb-2">
+            <Badge variant="outline" className="gap-1">
+              <Calendar className="h-3 w-3" />
+              {proceedingLabel}
+            </Badge>
+            {cleanOfficialPoint && (
+              <Badge variant="outline" className="gap-1">
+                {cleanOfficialPoint}
+              </Badge>
+            )}
             {hasVotes && (
               <Badge variant="secondary" className="gap-1">
                 <Vote className="h-3 w-3" />

--- a/lib/supabase/getProceedings.ts
+++ b/lib/supabase/getProceedings.ts
@@ -14,6 +14,7 @@ type ProceedingDayPoint = {
   topic: string
   summary_tldr: string | null
   voting_numbers: number[]
+  official_point: string | null
   proceeding_day: {
     date: string
     proceeding: {
@@ -31,7 +32,7 @@ export const getLatestProceedingPoints = cache(async (category?: string): Promis
     supabase
       .from('proceeding_point_ai')
       .select(`
-        id, topic, summary_tldr, voting_numbers,
+        id, topic, summary_tldr, voting_numbers, official_point,
         proceeding_day!inner (
           date,
           proceeding!inner (number, title)
@@ -81,6 +82,7 @@ export const getLatestProceedingPoints = cache(async (category?: string): Promis
         proceedingNumber: point.proceeding_day.proceeding.number,
         date: point.proceeding_day.date,
         votingNumbers: point.voting_numbers,
+        officialPoint: point.official_point || null,
         votes,
       }
     })
@@ -94,7 +96,7 @@ export const getPopularProceedingPoints = cache(async (): Promise<LatestPointsRe
     supabase
       .from('proceeding_point_ai')
       .select(`
-        id, topic, summary_tldr, voting_numbers,
+        id, topic, summary_tldr, voting_numbers, official_point,
         proceeding_day!inner (
           date,
           proceeding!inner (number, title)
@@ -146,6 +148,7 @@ export const getPopularProceedingPoints = cache(async (): Promise<LatestPointsRe
         proceedingNumber: point.proceeding_day.proceeding.number,
         date: point.proceeding_day.date,
         votingNumbers: point.voting_numbers,
+        officialPoint: point.official_point || null,
         votes: voteData.votes,
       }
     })
@@ -169,6 +172,18 @@ export const getAllCategories = cache(async (): Promise<string[]> => {
     .sort(([, a], [, b]) => b - a)
     .slice(0, 5)
     .map(([category]) => category)
+})
+
+export const getMaxProceedingNumber = cache(async (): Promise<number> => {
+  const supabase = await createClient()
+  const { data } = await supabase
+    .from('proceeding')
+    .select('number')
+    .order('number', { ascending: false })
+    .limit(1)
+    .single()
+
+  return data?.number || 0
 })
 
 type ProceedingFromDB = {

--- a/lib/types/proceeding.ts
+++ b/lib/types/proceeding.ts
@@ -73,6 +73,7 @@ export interface LatestPointsResult {
   proceedingNumber: number
   date: string
   votingNumbers: number[]
+  officialPoint: string | null
 }
 
 export interface Vote {


### PR DESCRIPTION
- Add proceeding number badge with calendar icon
- Display official point number (cleaned up text)
- Add dynamic indicators for latest and second-to-last proceedings
- Separate badges into new line below category
- Fetch max proceeding number from database for dynamic labeling
- Update .gitignore to exclude .claude folder