### PR TITLE
fix: use NEXT_PUBLIC_SITE_URL for OAuth callback redirects

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -5,7 +5,10 @@ export async function GET(request: Request) {
   const requestUrl = new URL(request.url)
   const code = requestUrl.searchParams.get('code')
   const next = requestUrl.searchParams.get('redirect_to') ?? '/'
-  const origin = requestUrl.origin
+
+  // Use NEXT_PUBLIC_SITE_URL to ensure correct redirect in containerized environments
+  // where request.origin returns the container hostname instead of the public URL
+  const origin = process.env.NEXT_PUBLIC_SITE_URL || requestUrl.origin
 
   if (code) {
     const supabase = await createClient()


### PR DESCRIPTION
Problem: After OAuth authentication, users were being redirected to the container hostname (e.g., https://e49d4c3f9bba:3000/) instead of the actual site URL (https://sejmofil.pl/).

Root cause: In containerized environments behind a reverse proxy, request.origin returns the internal container hostname, not the public URL.

Solution: Use NEXT_PUBLIC_SITE_URL environment variable (which contains the correct public URL) for all redirects in the OAuth callback handler, with request.origin as a fallback for local development.

This ensures users are properly redirected to sejmofil.pl after successful authentication, regardless of the container's internal hostname.